### PR TITLE
Fix editor positioning with toolbar

### DIFF
--- a/packages/grid-table-kanban/src/grid/InteractionLayer.tsx
+++ b/packages/grid-table-kanban/src/grid/InteractionLayer.tsx
@@ -476,7 +476,7 @@ export const InteractionLayerBase: ForwardRefRenderFunction<
               }
 
               if (type === CellRegionType.ToggleEditing) {
-                return setEditing(true);
+                return requestAnimationFrame(() => setEditing(true));
               }
             }
           );
@@ -507,22 +507,40 @@ export const InteractionLayerBase: ForwardRefRenderFunction<
   };
 
   const onDblClick = () => {
+    // Prefer current selection/activeCell to avoid mouse hit-test races
+    // 1) Column header resizing/autofit via column selection
+    if (selection.type === SelectionRegionType.Columns && selectionRanges.length > 0) {
+      const [startCol, endCol] = selectionRanges[0];
+      if (startCol === endCol) {
+        return onColumnHeaderDblClick?.(startCol, {
+          x: coordInstance.getColumnRelativeOffset(startCol, scrollLeft),
+          y: 0,
+          width: coordInstance.getColumnWidth(startCol),
+          height: columnHeadHeight,
+        });
+      }
+    }
+
+    // 2) Cell editing via active cell (must match selection)
+    if (isCellSelection && activeCell) {
+      const [col, realRow] = activeCell;
+      const cell = getCellContent([col, realRow]) as IInnerCell;
+      if (cell.readonly) return onCellDblClick?.([col, realRow]);
+      editorContainerRef.current?.focus?.();
+      return requestAnimationFrame(() => setEditing(true));
+    }
+
+    // 3) Fallback to mouse hit only if no valid selection present (kept for completeness)
     const mouseState = getMouseState();
     const { type, rowIndex, columnIndex } = mouseState;
     const { realIndex } = getLinearRow(rowIndex);
-    if (
-      [RegionType.Cell, RegionType.ActiveCell].includes(type) &&
-      isEqual(selectionRanges[0], [columnIndex, realIndex])
-    ) {
+    if ([RegionType.Cell, RegionType.ActiveCell].includes(type)) {
       const cell = getCellContent([columnIndex, realIndex]) as IInnerCell;
       if (cell.readonly) return onCellDblClick?.([columnIndex, realIndex]);
       editorContainerRef.current?.focus?.();
-      return setEditing(true);
+      return requestAnimationFrame(() => setEditing(true));
     }
-    if (
-      type === RegionType.ColumnHeader &&
-      isEqual(selectionRanges[0], [columnIndex, columnIndex])
-    ) {
+    if (type === RegionType.ColumnHeader) {
       return onColumnHeaderDblClick?.(columnIndex, {
         x: coordInstance.getColumnRelativeOffset(columnIndex, scrollLeft),
         y: 0,
@@ -736,6 +754,8 @@ export const InteractionLayerBase: ForwardRefRenderFunction<
         width,
         height,
         cursor,
+        top: 0,
+        left: 0,
       }}
       className="absolute"
     >


### PR DESCRIPTION
Anchor InteractionLayer to top:0, left:0 and defer editing to next frame to fix editor position offset and double-click timing issues.

The `InteractionLayer`'s absolute positioning was implicitly anchored to the static flow, causing an offset equal to the toolbar height when a toolbar was present. Additionally, a race condition existed where double-click events could trigger editing before `selection/activeCell` was fully updated, leading to the wrong cell being edited. This PR explicitly anchors the `InteractionLayer` and ensures editing is deferred to the next frame, resolving these issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-64ced4d2-b250-4bfc-bf38-a8a9f5586235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64ced4d2-b250-4bfc-bf38-a8a9f5586235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

